### PR TITLE
Removes redundant try-except in plane_cost

### DIFF
--- a/holiday.py
+++ b/holiday.py
@@ -22,19 +22,18 @@ def plane_cost(city_flight):
     Barcelona: £120 
     Melbourne: £780
     '''
-    try:
-        if city_flight == 'New York':
-            return 450
-        elif city_flight == 'Roma':
-            return 80
-        elif city_flight == 'Barcelona':
-            return 120
-        elif city_flight == 'Melbourne':
-            return 780
-        else:
-            return "Invalid Destination. Try again!"
-    except ValueError as e:
-        return e
+
+    if city_flight == 'New York':
+        return 450
+    elif city_flight == 'Roma':
+        return 80
+    elif city_flight == 'Barcelona':
+        return 120
+    elif city_flight == 'Melbourne':
+        return 780
+    else:
+        return "Invalid Destination. Try again!"
+
 
 
 def car_rental(rental_days):


### PR DESCRIPTION
As per the issue#1 the redundant try-except block has been removed from the plane_cost function. This block is unnecessary due to the if-else statements that compares the passed string in the function and if a wrong input or destination is entered the user is informed. 